### PR TITLE
British voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ $ npm install google-tts-api --save
 ``` js
 var googleTTS = require('google-tts-api');
 
-googleTTS('Hello World', 'en', 1)   // speed normal = 1 (default), slow = 0.24
+// text to speak (a string)
+// lang (see google translate for supported languages)
+// speed normal = 1 (default), slow = 0.24
+// timeout in milliseconds = 1000 (default)
+// accent american = 'us' (default), british = 'uk'
+googleTTS('Hello World', 'en', 1, 1000, 'us')
 .then(function (url) {
   console.log(url); // https://translate.google.com/translate_tts?...
 })

--- a/example/british.js
+++ b/example/british.js
@@ -1,0 +1,11 @@
+"use strict";
+
+var googleTTS = require('..');
+
+googleTTS('Hello Britain', 'en', 1, 1000, 'uk')   // speed normal = 1 (default), slow = 0.24
+.then(function (url) {
+  console.log(url); // https://translate.google.co.uk/translate_tts?...
+})
+.catch(function (err) {
+  console.error(err.stack);
+});

--- a/index.js
+++ b/index.js
@@ -8,10 +8,11 @@ var tts = require('./lib/api');
  * @param   {String!} lang     default is 'en'
  * @param   {Number!} speed    default is 1, show = 0.24
  * @param   {Number!} timeout  default is 10000ms
+ * @param   {String}  accent   default is 'us', otherwise 'uk' 
  * @return  Promise(url: String)
  */
-module.exports = function (text, lang, speed, timeout) {
+module.exports = function (text, lang, speed, timeout, accent) {
   return key(timeout).then(function (key) {
-    return tts(text, key, lang, speed);
+    return tts(text, key, lang, speed, accent);
   });
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,7 @@
 var url = require('url');
 var token = require('./token');
-var host = 'https://translate.google.com';
+var ushost = 'https://translate.google.com';
+var ukhost = 'https://translate.google.co.uk';
 
 /**
  * Generate "Google TTS" audio download link
@@ -9,9 +10,10 @@ var host = 'https://translate.google.com';
  * @param   {String}  key
  * @param   {String!} lang   default is 'en'
  * @param   {Number!} speed  show = 0.24, default is 1
+ * @param   {String}  accent   default is 'us', otherwise 'uk'
  * @return  {String}  url
  */
-module.exports = function (text, key, lang, speed) {
+module.exports = function (text, key, lang, speed, accent) {
   if (typeof text !== 'string' || text.length === 0) {
     throw new TypeError('text should be a string');
   }
@@ -27,6 +29,12 @@ module.exports = function (text, key, lang, speed) {
   if (typeof speed !== 'undefined' && typeof speed !== 'number') {
     throw new TypeError('speed should be a number');
   }
+
+  if (typeof accent !== 'undefined' && accent !== 'us' && accent !== 'uk') {
+    throw new TypeError('accent must be "us" or "uk"');
+  }
+
+  var host = accent === 'uk' ? ukhost : ushost;
 
   return host + '/translate_tts' + url.format({
     query: {

--- a/test/en.js
+++ b/test/en.js
@@ -42,4 +42,13 @@ describe('English TTS', function() {
       .then(function (res) { return res.status })
     ).to.eventually.equal(200);
   });
+
+  it('hello uk', function () {
+    expect(
+      tts('hello uk', 'en', 1, 'uk')
+      .then(function (url) { return fetch(url) })
+      .then(function (res) { return res.status })
+    ).to.eventually.equal(200);
+  });
+
 });

--- a/test/param.js
+++ b/test/param.js
@@ -63,4 +63,24 @@ describe('parameters', function() {
       tts('test', 'en', 1, 10)
     ).to.eventually.be.rejectedWith(Error);
   });
+
+  it("accent = null", function () {
+    return expect(
+      tts('test', 'en', 1, 1000, null)
+    ).to.eventually.be.rejectedWith(TypeError);
+  });
+
+  it("accent = ''", function () {
+    return expect(
+      tts('test', 'en', 1, 1000, '')
+    ).to.eventually.be.rejectedWith(TypeError);
+  });
+
+
+  it("accent = 'en'", function () {
+    return expect(
+      tts('test', 'en', 1, 1000, 'en')
+    ).to.eventually.be.rejectedWith(TypeError);
+  });
+
 });


### PR DESCRIPTION
Hi Leon -

Here's a pull request if you're interested (I hope you are!) that adds an optional 'accent' parameter which causes it to generate speech using the british accent voice used at the uk version of google translate instead the normal american accent voice.

I'm actually not british btw it's just I'd been playing with another module "google-home-notifier" which uses your module, and I was getting tired of the american voice all the time!  Originally I'd hoped maybe there was an option for a male voice or something but googling it seemed this still-female-but-british-accent-voice is the only other option possible.  But it was easy to do and I thought - what the heck better than no other option at all...

I tried to follow all your patterns e.g. with the parameter type checking and your tests etc.

Though the change is actually trivial - all it does is generate the url using "https://translate.google.co.uk" on the front instead of the normal "https://translate.google.com".

Hope you're interested.

I didn't make a fuss about the change in your README btw but I did expand the example you show there just enough to illustrate that the option is there...

