### PR TITLE
Update TKK key setting after Google Translate changes

### DIFF
--- a/lib/key.js
+++ b/lib/key.js
@@ -18,15 +18,10 @@ module.exports = function (timeout) {
     return res.text();
   })
   .then(function (html) {
-    var TKK = null;
+    var match = html.match("TKK='(\\d+.\\d+)';");
 
-    try {
-      eval(html.match(/TKK=eval\(\'\(.*\)\'\);/g)[0]);  // TKK = '405291.1334555331'
-      if (TKK === null) throw null;
-    } catch (e) {
-      throw new Error('get key failed from google');
-    }
+    if (!match) throw new Error('get key failed from google');
 
-    return TKK;
+    return match[1];
   });
 };


### PR DESCRIPTION
Looks like Google made changes again.

Previously, it looked something like this:

```
TKK=eval('((function(){var a\x3d3108463691;var b\x3d-1424084331;return 425984+\x27.\x27+(a+b)})())');
```

Now, they have simplified it (who knows for how long):

```
TKK='427081.2713004511';
```