### PR TITLE
fix typo

### DIFF
--- a/lib/key.js
+++ b/lib/key.js
@@ -23,7 +23,7 @@ module.exports = async (timeout = 10000) => {
     const html = await res.text();
     const token = html.match(/tkk:'(\d+.\d+)'/);
     if (!token) {
-      await delay(retry.interval); // retry after 500 ms
+      await delay(retry.interval); // retry after 50 ms
       continue;
     }
     return token[1];


### PR DESCRIPTION
About the retry feature in the `lib/key.js`, the comment says "retry after 500 ms" but the actual value is 50 (ms). This pull request fixes this.

For now I increased the interval to 500 ms because I feel that 50 ms is too short as an interval.
If the 50 ms was correct and the comment was wrong, please tell me. I'll fix this pull request.

https://github.com/zlargon/google-tts/blob/f7157430d1d8a084e6d43fc10bc643af096d2dee/lib/key.js#L5-L8

https://github.com/zlargon/google-tts/blob/f7157430d1d8a084e6d43fc10bc643af096d2dee/lib/key.js#L26